### PR TITLE
Fix typo in playbook title

### DIFF
--- a/examples/3 - Building an interactive view.ipynb
+++ b/examples/3 - Building an interactive view.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Intercative widgets: Adding sliders, buttons\n"
+    "# Interactive widgets: Adding sliders, buttons\n"
    ]
   },
   {


### PR DESCRIPTION
Example playbook 3 - Building an interactive view has a typo in the title. This PR aims at fixing it.

